### PR TITLE
Make `repo` directory to work with both local and GitHub CI builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,6 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
 
-      - name: compile
+      - name: install
         run: |
-          sed -i "s|CURRENTFOLDER|$(pwd)|g" pom.xml
-          mvn compile
+          mvn clean install

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
     <properties>
         <jpro.version>2024.3.0</jpro.version>
         <jpro-platform.version>0.4.0</jpro-platform.version>
+        <local.repo.dir>${project.basedir}/../repo</local.repo.dir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tinkar-core.groupId>dev.ikm.tinkar</tinkar-core.groupId>
         <tinkar-core.version>1.51.0</tinkar-core.version>
@@ -93,7 +94,7 @@
     <repositories>
         <repository>
             <id>local-repo L1</id>
-            <url>file://CURRENTFOLDER/repo</url>
+            <url>file://${local.repo.dir}</url>
         </repository>
     </repositories>
     <dependencyManagement>


### PR DESCRIPTION
Correct the local repository URL for the `repo` directory to ensure compatibility with both local builds and GitHub CI builds.