### PR TITLE
Fix for Jira JPRO-18

### DIFF
--- a/application/src/main/java/dev/ikm/komet/app/SelectDataSourceController.java
+++ b/application/src/main/java/dev/ikm/komet/app/SelectDataSourceController.java
@@ -109,8 +109,12 @@ public class SelectDataSourceController {
 
         propertySheet.setPropertyEditorFactory(new KometPropertyEditorFactory(null));
 
-        Platform.runLater(() ->
-                dataSourceChoiceBox.getSelectionModel().select(controllerOptions.get(1)));
+        controllerOptions.stream()
+                .filter(dataServiceController -> dataServiceController.controllerName().equals("Open SpinedArrayStore"))
+                .findFirst()
+                .ifPresentOrElse(dataServiceController -> dataSourceChoiceBox.getSelectionModel().select(dataServiceController),
+                        // If default data service is not found, select the first one on the choice box.
+                        () -> dataSourceChoiceBox.getSelectionModel().selectFirst());
     }
 
     void dataSourceChanged(ObservableValue<? extends DataServiceController<?>> observable,


### PR DESCRIPTION
- Current behavior:
On app startup, when running KOMET with JPro the default data service selected on the Startup dialog box is
`New Spined Array Store`.

- Expected behavior:
On app startup, the default selected data service on the KOMET Startup dialog box should be `Open SpinedArrayStore`, independent of the platform.