### PR TITLE
Update JPro to latest release version `2024.3.1`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <module>application</module>
     </modules>
     <properties>
-        <jpro.version>2024.3.0</jpro.version>
+        <jpro.version>2024.3.1</jpro.version>
         <jpro-platform.version>0.4.0</jpro-platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tinkar-core.groupId>dev.ikm.tinkar</tinkar-core.groupId>


### PR DESCRIPTION
This [update](https://www.jpro.one/docs/current/3.1/2024.3.X) brings several improvements to the Komet-JPro project, addressing key issues as outlined in the following Jira tickets:

1. **JPRO-13**: Allows users to copy text from **non-editable** TextField components using the keyboard.
2. **JPRO-21**: Fixes the icon rendering in the Concept window, ensuring in general that all complex icons with the `evenodd` filling rule are displayed correctly in the browser.

**Additional Information**

While a separate PR will be created for JPRO-17: Containerize JPro Application, this update includes some preliminary changes related to the topic.